### PR TITLE
Retry even if there is a build error

### DIFF
--- a/lib/fastlane/plugin/retry/version.rb
+++ b/lib/fastlane/plugin/retry/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Retry
-    VERSION = "1.1.0"
+    VERSION = "1.1.5"
   end
 end


### PR DESCRIPTION
Retry even if `xcodebuild` fails. This is to account for various environment failures like simulator crashes.